### PR TITLE
Hoist non-react statics to the universal wrapper component, fixes #68

### DIFF
--- a/example/src/index.html.js
+++ b/example/src/index.html.js
@@ -19,7 +19,6 @@ main.routes = {
 }
 
 function getMessage() {
-
   return getApp().database().ref('read-only').child('message').once('value').then(snap => snap.val())
 
   function getApp() {
@@ -57,6 +56,9 @@ function main ({ location, data }) {
         </p>
         <span className={styles.test}>Something</span>
         <Test soep='kip' initialMessage={ data.message } clientConfig={config.client} />
+
+        Test static message, wrapped with universal wrapper: "{Test.message}"
+        <br /><br />
         <div className={styles.multipleBackground}>multiple backgrounds</div>
         <div className={styles.svgBackground}>svg background</div>
         <img src={publicSvg} /> public svg ({publicSvg})

--- a/example/src/partials/Test.js
+++ b/example/src/partials/Test.js
@@ -7,6 +7,8 @@ const extra = { x: 'x' }
 
 export default class Test extends Component {
 
+  static message = 'Works!'
+
   state = {
     counter: 0,
     asyncValue: null,

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -47,7 +47,7 @@
     through2 "^2.0.0"
 
 "@kaliber/build@file:../library":
-  version "0.0.32"
+  version "0.0.33"
   dependencies:
     "@kaliber/config" "^0.0.1"
     ansi-regex "^3.0.0"
@@ -71,6 +71,7 @@
     gm "^1.23.0"
     helmet "^3.8.1"
     history "^4.6.1"
+    hoist-non-react-statics "^2.3.1"
     image-maxsize-webpack-loader "^1.0.0"
     image-webpack-loader "^3.3.0"
     json-loader "^0.5.7"
@@ -3031,6 +3032,10 @@ hoek@2.x.x:
 hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
+
+hoist-non-react-statics@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"

--- a/library/package.json
+++ b/library/package.json
@@ -30,6 +30,7 @@
 		"gm": "^1.23.0",
 		"helmet": "^3.8.1",
 		"history": "^4.6.1",
+		"hoist-non-react-statics": "^2.3.1",
 		"image-maxsize-webpack-loader": "^1.0.0",
 		"image-webpack-loader": "^3.3.0",
 		"json-loader": "^0.5.7",

--- a/library/webpack-loaders/react-universal-server-loader.js
+++ b/library/webpack-loaders/react-universal-server-loader.js
@@ -25,7 +25,10 @@ function createServerCode({ importPath, scriptSrc, id }) {
        |\` }} />`.split(/^[ \t]*\|/m).join('')
 
   return `|import Component from './${importPath}'
+          |import assignStatics from 'hoist-non-react-statics'
           |import { renderToString } from 'react-dom/server'
+          |
+          |assignStatics(WrapWithScript, Component)
           |
           |export default function WrapWithScript(props) {
           |  const content = renderToString(<Component id='${id}' {...props} />)

--- a/library/yarn.lock
+++ b/library/yarn.lock
@@ -2599,6 +2599,10 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
+hoist-non-react-statics@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"


### PR DESCRIPTION
A use case could be a `<Page />` component which renders the html, head and body, but needs to know things like the title and description for its meta-tags.

```js
import Page from 'Page'
import ContactPage from `pages/ContactPage.js?universal`

export default function Index () {
   return (
    <Page title={ContactPage.meta.title}>
      <ContactPage />
    </Page>
  )
}

// ContactPage.js

ContactPage.meta = {
  title: 'Contact us!',
  // description, og:image, etc
}

export default function ContactPage () {
  return <p>Contact</p>
}