### PR TITLE
using `svg-url-loader` on svg images - fixes #56

### DIFF
--- a/example/src/index.html.js.css
+++ b/example/src/index.html.js.css
@@ -29,7 +29,7 @@
 }
 
 .svgBackground {
-  background: url('./red.svg');
+  background: url("./red.svg");
   background-repeat: no-repeat, no-repeat;
   background-position: top left, top right;
   width: 600px;

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -174,6 +174,7 @@
     react "^15.6.1"
     react-dom "^15.6.1"
     source-map "^0.5.6"
+    svg-url-loader "^2.2.0"
     url-loader "^0.5.8"
     walk-sync "^0.3.1"
     webpack "^3.5.5"
@@ -3009,7 +3010,7 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
-file-loader@^0.11.2:
+file-loader@0.11.2, file-loader@^0.11.2:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-0.11.2.tgz#4ff1df28af38719a6098093b88c82c71d1794a34"
   dependencies:
@@ -4521,6 +4522,14 @@ loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
 
+loader-utils@1.1.0, loader-utils@^1.0.2, loader-utils@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
+
 loader-utils@^0.2.16:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
@@ -4529,14 +4538,6 @@ loader-utils@^0.2.16:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
     object-assign "^4.0.1"
-
-loader-utils@^1.0.2, loader-utils@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
-  dependencies:
-    big.js "^3.1.3"
-    emojis-list "^2.0.0"
-    json5 "^0.5.0"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -7307,6 +7308,13 @@ supports-color@^4.0.0, supports-color@^4.2.1, supports-color@^4.4.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
   dependencies:
     has-flag "^2.0.0"
+
+svg-url-loader@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/svg-url-loader/-/svg-url-loader-2.2.0.tgz#107e02a3e5127c23e5a0a76ba32392df39f5ad98"
+  dependencies:
+    file-loader "0.11.2"
+    loader-utils "1.1.0"
 
 svgo@^0.7.0:
   version "0.7.2"

--- a/library/lib/build.js
+++ b/library/lib/build.js
@@ -169,8 +169,13 @@ module.exports = function build({ watch }) {
             test: /\.svg$/,
             loaders: [
               {
-                loader: 'url-loader',
-                options: { limit: 5000 }
+                loader: 'svg-url-loader',
+                options: {
+                  limit: 5000,
+                  noquotes: true,
+                  stripdeclarations: true,
+                  iesafe: true
+                }
               },
               imageLoader
             ]

--- a/library/package.json
+++ b/library/package.json
@@ -61,6 +61,7 @@
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "source-map": "^0.5.6",
+    "svg-url-loader": "^2.2.0",
     "url-loader": "^0.5.8",
     "walk-sync": "^0.3.1",
     "webpack": "^3.5.5",

--- a/library/yarn.lock
+++ b/library/yarn.lock
@@ -2425,7 +2425,7 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
-file-loader@^0.11.2:
+file-loader@0.11.2, file-loader@^0.11.2:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-0.11.2.tgz#4ff1df28af38719a6098093b88c82c71d1794a34"
   dependencies:
@@ -3598,6 +3598,14 @@ loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
 
+loader-utils@1.1.0, loader-utils@^1.0.2, loader-utils@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
+
 loader-utils@^0.2.16:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
@@ -3606,14 +3614,6 @@ loader-utils@^0.2.16:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
     object-assign "^4.0.1"
-
-loader-utils@^1.0.2, loader-utils@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
-  dependencies:
-    big.js "^3.1.3"
-    emojis-list "^2.0.0"
-    json5 "^0.5.0"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -5676,6 +5676,13 @@ supports-color@^4.0.0, supports-color@^4.2.1, supports-color@^4.4.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
   dependencies:
     has-flag "^2.0.0"
+
+svg-url-loader@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/svg-url-loader/-/svg-url-loader-2.2.0.tgz#107e02a3e5127c23e5a0a76ba32392df39f5ad98"
+  dependencies:
+    file-loader "0.11.2"
+    loader-utils "1.1.0"
 
 svgo@^0.7.0:
   version "0.7.2"


### PR DESCRIPTION
This comes at a price, you are now required to include your svg files (from `.css`) in `"` (double quotes).

The loader can do this for you, but then you would have a problem if you were to try loading this into an `img` tag.

Is there a way around this? This is tricky because in the html `src` attribute the value is enclosed in `"..."` (double quotes) anyways.

We could theoretically work around this in our `css-loader` and add a special case for svg files: if the data starts with `data:image/svg+xml` replace any `'` (single quote) with an escaped version: `\'`. This would however require us to load them using single quotes. I don't think we want to go this route.

So I think the options are:
- use base64 (default `url-loader`) - this article votes against this: [Optimizing SVGs in data URIs](https://codepen.io/tigt/post/optimizing-svgs-in-data-uris)
- use double quotes when typing `url("./xxx.svg")`
- create a postcss plugin, or adjust the `lib/postcss-plugins/postcss-url-replace` plugin to do some magic

Any feedback is welcome :-)