### PR TITLE
Add automatic version detection

### DIFF
--- a/library/.eslintrc
+++ b/library/.eslintrc
@@ -14,7 +14,12 @@
 
   "settings": {
     "import/resolver": {
-      "@kaliber/build/eslint-resolver-plugins/absolute-path-resolver-plugin": { path: './src' }
+      "@kaliber/build/eslint-resolver-plugins/absolute-path-resolver-plugin": {
+        "path": "./src"
+      }
+    },
+    "react": {
+      "version": "detect"
     }
   },
 


### PR DESCRIPTION
Prevents a warning on clean install.
=> Warning: React version not specified in eslint-plugin-react settings