### PR TITLE
Added postcss-calc to the css loaders

### DIFF
--- a/docs/src/content/conventions/index.raw.md
+++ b/docs/src/content/conventions/index.raw.md
@@ -154,18 +154,23 @@ modules plugin is configured with `global` as it's scope behavior.
 
 #### `*.css (excluding node_modules)`
 
-The css files from your project are loaded using or own CSS loader. This loader uses postcss which
+The css files from your project are loaded using our own CSS loader. This loader uses postcss which
 is configured to use the following plugins:
 
-- `postcss-import`      - Allows for `@import` statements in CSS.
-- `postcss-apply`       - Allows for `@apply` statements in CSS.
-- `postcss-modules`     - Adds module support to CSS. Importing a CSS file into javascript provides
-                          an object that contains the original class names as key and locally scoped
-                          class names as value.
-- `postcss-url-replace` - Our own plugin that makes sure all `url` references are loaded using the
-                          defined Webpack loaders.
-- `postcss-next`        - Use the CSS of tomorrow today.
-- `cssnano`             - Is only used when `NODE_ENV=production` and minifies the javascript.
+- `postcss-import`                    - Allows for `@import` statements in CSS.
+- `postcss-apply`                     - Allows for `@apply` statements in CSS.
+- `postcss-preset-env`                - Use tomorrow’s CSS today.
+- `postcss-modules-values`            - Pass arbitrary values between your module files.
+- `postcss-modules-local-by-default`  - Make :local scope the default.
+- `postcss-modules-scope`             - A CSS Modules transform to extract export statements from local-scope 
+                                        classes. Importing a CSS file into javascript provides an object that 
+                                        contains the original class names as key and locally scoped class names
+                                        as value.
+- `postcss-calc`                      - Reduce calc() references whenever it's possible.
+- `postcss-url-replace`               - Our own plugin that makes sure all `url` references are loaded using the
+                                        defined Webpack loaders.
+- `postcss-import-export-parser`      - CSS imports and exports parser.
+- `cssnano`                           - Is only used when `NODE_ENV=production` and minifies the javascript.
 
 #### `*.css (if not matched by another pattern)`
 

--- a/example/src/partials/Test.js
+++ b/example/src/partials/Test.js
@@ -7,6 +7,7 @@ import img from '/bg2.jpg'
 import Sticky from 'react-stickynode'
 import firebase from 'firebase/app'
 import 'firebase/database'
+import { testCalc } from '/partials/values.css'
 const extra = { x: 'x' }
 
 export default class Test extends Component {
@@ -52,6 +53,7 @@ export default class Test extends Component {
     console.log(this.state)
     console.log(json)
     console.log(new (getDecorator())().x)
+    console.log('The following value should be -1rem:', testCalc)
     this.asyncFunction()
     this.interval = setInterval(() => this.setState(({ counter }) => ({ counter: counter + 1 })), 1000)
 

--- a/example/src/partials/values.css
+++ b/example/src/partials/values.css
@@ -1,1 +1,3 @@
 @value test: goldenrod;
+@value test2: 1rem;
+@value testCalc: calc(-1 * test2);

--- a/library/package.json
+++ b/library/package.json
@@ -59,6 +59,7 @@
     "pkg-dir": "^4.2.0",
     "postcss": "^7.0.17",
     "postcss-apply": "^0.12.0",
+    "postcss-calc": "^7.0.1",
     "postcss-import": "^12.0.0",
     "postcss-modules-local-by-default": "^3.0.2",
     "postcss-modules-scope": "^2.1.0",

--- a/library/webpack-loaders/css-loader.js
+++ b/library/webpack-loaders/css-loader.js
@@ -37,6 +37,7 @@ function createPlugins(loaderOptions, { resolveForImport, resolveForUrlReplace, 
         require('postcss-modules-values'),
         !globalScopeBehaviour && require('postcss-modules-local-by-default')(),
         require('postcss-modules-scope')({ generateScopedName: genericNames(isProduction ? '[hash:base64:5]' : '[folder]-[name]-[local]__[hash:base64:5]') }),
+        require('postcss-calc'),
         require('../postcss-plugins/postcss-import-export-parser')({ loadExports: resolveForImportExportParser }),
 
         require('../postcss-plugins/postcss-url-replace')({ replace: resolveForUrlReplace }),


### PR DESCRIPTION
This PR add the postcss `postcss-calc` plugin.

The plugin rewrites calcs to inline values where possible. E.g. `calc(-1 * 2rem)` becomes `-2rem`. The main usecase for this is for use in transforms in IE11. IE11 has a quirk where transform values with calcs in them are not valid, making it difficult to transform your variables to negative values.