### PR TITLE
fix automatic imports

### DIFF
--- a/library/template/tsconfig.json
+++ b/library/template/tsconfig.json
@@ -14,8 +14,8 @@
     "checkJs": true,
     "noEmit": true,
     "paths": {
-      "/*?universal": ["src/*"],
-      "/*": ["src/*"]
+      "/*": ["src/*"],
+      "/*?universal": ["src/*"]
     }
   }
 }


### PR DESCRIPTION
It now prefers the version without `?universal` which is much more common.