### PR TITLE
Fix stylelint message concerning usage of `unset`

### DIFF
--- a/library/stylelint-plugins/rules/parent-child-policy/index.js
+++ b/library/stylelint-plugins/rules/parent-child-policy/index.js
@@ -21,12 +21,12 @@ const messages = {
     `missing \`display: flex;\`\n` +
     `\`${prop}\` can only be used when the containing root rule has \`display: flex;\` - ` +
     `add \`display: flex;\` to the containing root rule or, if this is caused by a media query ` +
-    `that overrides \`display: flex;\`, use \`flex: unset\``,
+    `that overrides \`display: flex;\`, use \`${prop}: unset\``,
   'nested - require display grid in parent': prop =>
     `missing \`display: grid;\`\n` +
     `\`${prop}\` can only be used when the containing root rule has \`display: grid;\` - ` +
     `add \`display: grid;\` to the containing root rule or, if this is caused by a media query ` +
-    `that overrides \`display: grid;\`, use \`grid: unset\``,
+    `that overrides \`display: grid;\`, use \`${prop}: unset\``,
   'invalid pointer events':
     `Incorrect pointer events combination\n` +
     `you can only set pointer events in a child if the parent disables pointer events - ` +


### PR DESCRIPTION
See: https://github.com/kaliberjs/build/issues/203