### PR TITLE
Remove common warning

### DIFF
--- a/library/lib/universalComponents.js
+++ b/library/lib/universalComponents.js
@@ -22,7 +22,6 @@ export function findComponents({ componentName }) {
 
   const findComponentCache = getFindComponentCache()
   const components = findComponentCache[componentName] || []
-  if (!components.length) console.warn(`Could not find any component with name '${componentName}', dit you render it to the page?`)
   return components
 
   function getFindComponentCache() {


### PR DESCRIPTION
This warning comes up in cases where there is no actual problem. In case
a site has a single server side entry point all of the potential
components are rendered to the site. We might investigate a route where
the script tag is rendered with the component, but this causes the
script to be present more than once if multiple versions of the same
component are on the page. For now removing the warning causes the
least amount of confusion.