### PR TITLE
Remove defer attribute from polyfill script

### DIFF
--- a/docs/src/content/how-to/polyfills.raw.md
+++ b/docs/src/content/how-to/polyfills.raw.md
@@ -23,7 +23,7 @@ export default (
       {polyfill(['default', 'es2015', 'es2016', 'es2017', 'fetch'])}
       {/*
         this will output: 
-        <script defer src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es2015,es2016,es2017,fetch" crossorigin="anonymous" />
+        <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es2015,es2016,es2017,fetch" crossorigin="anonymous" />
       */}
     </head>
     <body />

--- a/library/lib/polyfill.js
+++ b/library/lib/polyfill.js
@@ -4,5 +4,5 @@ export default function polyfill(features = []) {
   const src = isProduction
     ? `https://cdn.polyfill.io/v3/polyfill.min.js?rum=0&unknown=polyfill&flags=gated&features=${features.join(',')}`
     : `https://cdn.polyfill.io/v3/polyfill.js?rum=0&unknown=polyfill&flags=gated&features=${features.join(',')}`
-  return <script defer src={src} crossOrigin="anonymous" />
+  return <script src={src} crossOrigin="anonymous" />
 }


### PR DESCRIPTION
In Node projecten wordt `defer` standaard op de polyfill script tag gezet in de `polyfill` functie. Op basis van https://kaliberinteract.slack.com/archives/C025GRZUL/p1661330729418279 denk ik dat we dit attribuut hier weg zouden moeten halen. Waarschijnlijk voegt dit wel wat latency toe aan onze websites.