### PR TITLE
Update splitChunks settings

### DIFF
--- a/library/lib/build.js
+++ b/library/lib/build.js
@@ -200,12 +200,8 @@ module.exports = function build({ watch }) {
         ],
         splitChunks: {
           chunks: 'all',
-          maxInitialRequests: 4,
-          cacheGroups: {
-            vendors: {
-              reuseExistingChunk: true,
-            },
-          }
+          minSize: 10000,
+          maxInitialRequests: 100,
         }
       },
       resolve: resolveOptions(),

--- a/library/lib/build.js
+++ b/library/lib/build.js
@@ -200,7 +200,12 @@ module.exports = function build({ watch }) {
         ],
         splitChunks: {
           chunks: 'all',
-          minSize: 10000
+          maxInitialRequests: 4,
+          cacheGroups: {
+            vendors: {
+              reuseExistingChunk: true,
+            },
+          }
         }
       },
       resolve: resolveOptions(),


### PR DESCRIPTION
Deze configuratie lijkt (voor HTTP1) de beste resultaten op te leveren als je kijkt naar totale size vs. unused bytes vs. duplicate code in chunks.

Dan kunnen we opnieuw naar de config kijken zodra HTTP2 in zicht is (Peter is daar mee bezig right?)