### PR TITLE
Updated linting rules

### DIFF
--- a/eslint-plugin/rules/layout-class-name/index.js
+++ b/eslint-plugin/rules/layout-class-name/index.js
@@ -17,6 +17,9 @@ const messages = {
     `Unexpected attribute 'className', only native (lower case) elements can have a 'className' - ` +
     `use 'layoutClassName' for manipulating layout`,
 
+  'invalid layoutClassName':
+    (found, expected) => `Unexpected layoutClassName '${found}', expected '${expected}'`,
+  
   'no export base':
     `Unexpected 'export', Base components can not be exported - remove the 'export' keyword`,
 }
@@ -53,6 +56,12 @@ module.exports = {
       },
       [`JSXAttribute[name.name = 'className']`](node) {
         reportClassNameOnCustomComponent(node)
+      },
+      [`JSXAttribute[name.name = 'layoutClassName'] MemberExpression[object.name = 'styles']`](node) {
+        reportInvalidLayoutClassName(node.property, node.property.name)
+      },
+      [`JSXAttribute[name.name = 'layoutClassName'] Literal`](node) {
+        reportInvalidLayoutClassName(node, node.value)
       },
       [`ExportNamedDeclaration > FunctionDeclaration`](node) {
         reportExportedBase(node)
@@ -93,6 +102,16 @@ module.exports = {
       context.report({
         message: messages['no className on custom component'],
         node,
+      })
+    }
+
+    function reportInvalidLayoutClassName(node, className) {
+      const expectedClassName = className.endsWith('Layout') ? className : className + 'Layout'
+
+      if (className === expectedClassName) return
+      context.report({
+        message: messages['invalid layoutClassName'](className, expectedClassName),
+        node: node,
       })
     }
 

--- a/eslint-plugin/rules/layout-class-name/readme.md
+++ b/eslint-plugin/rules/layout-class-name/readme.md
@@ -2,8 +2,9 @@
 
 Passing a `className` to a custom component is considered harmful. Components should be treated as a black box. Doing so allows you to change the inner details of a component as long as you keep the public API unchanged. In other words: it does not make sense to give a custom component a `className` because you don't know what is inside.
 
-This however poses a problem when you want to position a custom component. To solve this common use case we introduced `layoutClassName`. As the name suggests, classes used as layout class name should
-only be used to manipulate layout and make no assumptions about the inner structure. When passing a `layoutClassName` you can assume it to be set as `className` on the top level element of the custom component.
+This however poses a problem when you want to position a custom component. To solve this common use case we introduced `layoutClassName`. As the name suggests, classes used as layout class name should only be used to manipulate layout and make no assumptions about the inner structure. When passing a `layoutClassName` you can assume it to be set as `className` on the top level element of the custom component.
+
+In order to track which classes are used as layout classes they must end with the suffix `Layout`. 
 
 Concretely, the following should be refactored as shown:
 
@@ -21,7 +22,7 @@ function MyComponent() {
 function MyComponent() {
   return (
     <div className={styles.component}>
-      <BlackBox layoutClassName={styles.blackBox} />
+      <BlackBox layoutClassName={styles.blackBoxLayout} />
     </div>
   )
 }
@@ -58,6 +59,9 @@ function Test({ layoutClassName }) {
 <div className={styles.test} />
 ```
 ```jsx
+<Test layoutClassName={styles.testLayout} />
+```
+```jsx
 <TestBase className={styles.test} />
 ```
 ```jsx
@@ -89,6 +93,9 @@ function Test({ layoutClassName }) {
 ```
 ```jsx
 <Test className={styles.test} />
+```
+```jsx
+<Test layoutClassName={styles.test} />
 ```
 ```jsx
 export function TestBase() {}

--- a/eslint-plugin/rules/layout-class-name/test.js
+++ b/eslint-plugin/rules/layout-class-name/test.js
@@ -17,6 +17,8 @@ test('layout-class-name', {
     `<div className='test' />`,
     `<div className={styles.test} />`,
     `<div {...{ className }} />`,
+    `<Test layoutClassName={styles.testLayout} />`,
+    `<Test layoutClassName='testLayout' />`,
     `<TestBase className='test' />`,
     `<TestBase className={styles.test} />`,
     `<TestBase {...{ className }} />`,
@@ -57,6 +59,18 @@ test('layout-class-name', {
     {
       code: `<Test {...{ className }} />`,
       errors: [{ message: messages['no className on custom component'], type: 'Property' }]
+    },
+    {
+      code: `<Test layoutClassName={styles.test} />`,
+      errors: [{ message: messages['invalid layoutClassName']('test', 'testLayout'), type: 'Identifier' }]
+    },
+    {
+      code: `<Test layoutClassName={cx(styles.test, styles.testLayout)} />`,
+      errors: [{ message: messages['invalid layoutClassName']('test', 'testLayout'), type: 'Identifier' }]
+    },
+    {
+      code: `<Test layoutClassName='test' />`,
+      errors: [{ message: messages['invalid layoutClassName']('test', 'testLayout'), type: 'Literal' }]
     },
     {
       code: `export function TestBase() {}`,

--- a/library/stylelint-plugins/rules/parent-child-policy/index.js
+++ b/library/stylelint-plugins/rules/parent-child-policy/index.js
@@ -1,6 +1,7 @@
 const {
   findDecls,
   parseSelector,
+  withRootRules,
   withNestedRules,
   isRoot, declMatches,
   getRootRules,
@@ -32,6 +33,9 @@ const messages = {
     `\`${prop}\` can only be used when the containing root rule has \`display: flex;\` or \`display: grid;\` - ` +
     `add \`display: flex;\` or \`display: grid;\` to the containing root rule or, if this is caused by a media query ` +
     `that overrides \`display: flex;\` or \`display: grid;\`, use \`${prop}: unset\``,
+  'layoutClassname - must be nested in a parent selector':
+    `layoutClassNames (classes ending with the \`Layout\` suffix) can only be targetted by a parent selector, using the direct child selector. ` + 
+    `Consequentially, you can only use layout related properties in layoutClassNames.`,
   'invalid pointer events':
     `Incorrect pointer events combination\n` +
     `you can only set pointer events in a child if the parent disables pointer events - ` +
@@ -119,6 +123,7 @@ module.exports = {
       requireDisplayFlexOrGridInParent({ root: modifiedRoot, report })
       validPointerEvents({ root: modifiedRoot, report })
       relativeToParent({ root: modifiedRoot, report })
+      requireLayoutClassNameToBeDirectChild({ root: modifiedRoot, report })
     }
   }
 }
@@ -187,6 +192,18 @@ function relativeToParent({ root, report }) {
     const result = checkChildParentRelation(rule, childParentRelations.relativeToParent)
     result.forEach(({ result, prop, triggerDecl, rootDecl, value, expectedValue }) => {
       report(triggerDecl, messages['missing position relative'])
+    })
+  })
+}
+
+function requireLayoutClassNameToBeDirectChild({ root, report }) {
+  withRootRules(root, rule => {
+    if (!rule.selector.includes('Layout')) return
+    parseSelector(rule).nodes.forEach(node => {
+      const className = node.nodes.find(x => x.type === 'class')
+      if (className && className.toString().endsWith('Layout')) {
+        report(rule, messages['layoutClassname - must be nested in a parent selector'])
+      }
     })
   })
 }

--- a/library/stylelint-plugins/rules/parent-child-policy/index.js
+++ b/library/stylelint-plugins/rules/parent-child-policy/index.js
@@ -40,10 +40,6 @@ const messages = {
     'Missing `position: relative;` in parent\n' +
     '`position: static` is only allowed when the containing root rule is set to `position: relative` - ' +
     'add `position-relative` to the containing root rule',
-  'missing relativeToParent className':
-    'Missing `.relativeToParent` className\n' +
-    '`position: static` can only be used when selecting on `.relativeToParent` - ' +
-    'add the `.relativeToParent` className',
 }
 
 // TODO: move errors into the different relations (would allows us to simplify the actual checks)
@@ -191,15 +187,6 @@ function relativeToParent({ root, report }) {
     const result = checkChildParentRelation(rule, childParentRelations.relativeToParent)
     result.forEach(({ result, prop, triggerDecl, rootDecl, value, expectedValue }) => {
       report(triggerDecl, messages['missing position relative'])
-    })
-    const triggerDecls = findDecls(rule, childParentRelations.relativeToParent.nestedHasOneOf)
-    triggerDecls.forEach(decl => {
-      const selectors = parseSelector(rule)
-      const hasValidSelectors = selectors.every(selector =>
-        selector.some(x => x.type === 'class' && x.value === 'relativeToParent')
-      )
-      if (hasValidSelectors) return
-      report(decl, messages['missing relativeToParent className'])
     })
   })
 }

--- a/library/stylelint-plugins/rules/parent-child-policy/readme.md
+++ b/library/stylelint-plugins/rules/parent-child-policy/readme.md
@@ -6,9 +6,9 @@ This rule helps you to correctly create these parent / child relationships.
 
 - [Stacking context](#stacking-context)
 - [Position absolute](#position-absolute)
+- [Escape stacking context with absolute children](#escape-stacking-context-with-absolute-children)
 - [Flex and Grid](#flex-and-grid)
 - [Pointer events](#pointer-events)
-- [Relative to parent](#relative-to-parent)
 
 ## Stacking context
 
@@ -68,114 +68,6 @@ When you given an element `position: absolute` the CSS engine will traverse its 
 
 This rule forces you set `position: relative` on the parent element in order to prevent the element from escaping a known context. It ensures we stay true to the black-box principle.
 
-## Relative to parent
-
-In some case you need to allow a child element to escape from it's parents context. An example:
-
-```html
-<ul class='menu'>
-  <li class='menu-item'>
-    Item 1
-    <ul class='menu-submenu'>
-      <li>Sub item 1</li>
-      ...
-    <ul>
-  </li>
-  ...
-</ul>
-```
-
-```css
-.menu {
-  display: flex;
-  position: relative;
-}
-
-.menu-item {
-  &.is-open {
-    & > .menu-submenu {
-      position: absolute;
-      ^^^^^^^^
-      left: 0;
-    }
-  }
-
-  &:not(.is-open) {
-    & > .menu-submenu {
-      display: none;
-    }
-  }
-}
-```
-
-The `position: absolute` property is marked as a problem because it escapes its parent. This means we need to add a `position: relative`.
-
-```css
-.menu-item {
-  position: relative;
-  &.is-open {
-    & > .menu-submenu {
-      position: absolute;
-      ...
-```
-
-While this solves the linting problem, we do not get the effect we wish to achieve: `submenu` rendered on the left of the `menu` while maintaining semantically correct html.
-
-In order for this to work we need to transform the CSS:
-
-```css
-.menu {
-  display: flex;
-  position: relative;
-
-  & > .menu-item.relativeToParent {
-    position: static;
-  }
-}
-
-.menu-item {
-  position: relative;
-  ...
-}
-```
-
-Note that we set `position: static` from the parent. You can also see we included the marker class `.relativeToParent`. If you would not use this exact name you would get another linting error. The reason we require this class is to make sure that the receiver of `position: static` is aware of this breach of containment. We would not want to accidentally break any behavior. As a bonus, you could use it in `menu-item` to toggle (enable / disable) this behavior:
-
-```css
-.menu-item {
-  &:not(.is-open) {
-    & > .menu-submenu {
-      display: none;
-    }
-  }
-
-  &.relativeToParent {
-    position: relative;
-
-    &.is-open {
-      & > .menu-submenu {
-        position: absolute;
-        left: 0;
-      }
-    }
-  }
-}
-```
-
-Note that this also works for removing a stacking context:
-
-```css
-.menu {
-  position: relative;
-  z-index: 0;
-
-  & > .item.relativeToParent {
-    position: static;
-    z-index: auto;
-  }
-}
-```
-
 ### Examples
 
 Examples of *correct* code for this rule:
@@ -214,6 +106,116 @@ Examples of *incorrect* code for this rule:
 .parent {
   &::after {
     position: absolute;
+  }
+}
+```
+
+## Escape stacking context with absolute children
+
+In some case you may need a child element to be relative to an element different from its parent: you want it to escape its parent's stacking context. An example:
+
+```html
+<ul class='menu'>
+  <li class='menu-item'>
+    Item 1
+    <ul class='menu-submenu'>
+      <li>Sub item 1</li>
+      ...
+    <ul>
+  </li>
+  ...
+</ul>
+```
+
+```css
+.menu {
+  display: flex;
+  position: relative;
+}
+
+.menu-item {
+  &.is-open {
+    & > .menu-submenu {
+      position: absolute;
+      ^^^^^^^^
+      left: 0;
+    }
+  }
+
+  &:not(.is-open) {
+    & > .menu-submenu {
+      display: none;
+    }
+  }
+}
+```
+
+The `position: absolute` property is marked as a problem because it escapes its parent's stacking context. This means we need to add a `position: relative`.
+
+```css
+.menu-item {
+  position: relative;
+
+  &.is-open {
+    & > .menu-submenu {
+      position: absolute;
+      left: 0;
+    }
+  }
+```
+
+While this solves the linting problem, we do not get the effect we wish to achieve: `submenu` rendered on the left of the `menu` while maintaining semantically correct html.
+
+In order for this to work we need to transform the CSS:
+
+```css
+.menu {
+  display: flex;
+  position: relative;
+
+  & > .menu-item {
+    position: static;
+  }
+}
+
+.menu-item {
+  position: relative;
+
+  &.is-open {
+    & > .menu-submenu {
+      position: absolute;
+      left: 0;
+    }
+  }
+}
+```
+
+Note that we reset the relative element to `position: static` from its parent. This way we explicitly allow the absolute child to escape this context, one level up to this parent. In order to allow this, you need to add `position: relative` to the parent, creating a _new_ stacking context. If you need the absolute element to escape further, you have to repeat this process:
+
+```css
+.a {
+  position: relative;
+
+  & > .b {
+    position: static;
+  }
+}
+
+.b {
+  position: relative;
+
+  & > .c {
+    position: static;
+  }
+}
+
+.c {
+  position: relative;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
   }
 }
 ```

--- a/library/stylelint-plugins/rules/parent-child-policy/test.js
+++ b/library/stylelint-plugins/rules/parent-child-policy/test.js
@@ -109,6 +109,16 @@ test('parent-child-policy', {
           }
         `,
       },
+      {
+        title: 'allow layoutClassName when targetted with the direct child selector',
+        code: `
+          .parent {
+            & > .childLayout {
+              margin: 0;
+            }
+          }
+        `,
+      }
     ],
     invalid: [
       {
@@ -291,6 +301,21 @@ test('parent-child-policy', {
         warnings: createMessages('nested - require display flex or grid in parent', [
           'order'
         ])
+      },
+      {
+        title: 'layoutClassName - must be nested in a parent selector',
+        code: `.badLayout { padding: 0; }`,
+        warnings: [messages['layoutClassname - must be nested in a parent selector']]
+      },
+      {
+        title: 'layoutClassName - must be nested in a parent selector',
+        code: `.badLayout:not(:empty) { padding: 0; }`,
+        warnings: [messages['layoutClassname - must be nested in a parent selector']]
+      },
+      {
+        title: 'layoutClassName - must be nested in a parent selector',
+        code: `.badLayout > .test { margin: 0; }`,
+        warnings: [messages['layoutClassname - must be nested in a parent selector']]
       },
     ]
   },

--- a/library/stylelint-plugins/rules/parent-child-policy/test.js
+++ b/library/stylelint-plugins/rules/parent-child-policy/test.js
@@ -61,24 +61,11 @@ test('parent-child-policy', {
         `
       },
       {
-        title: 'allow position: static 1',
-        code: `
-          .test {
-            position: relative;
-
-            & > .relativeToParent {
-              position: static;
-            }
-          }
-        `
-      },
-      {
-        title: 'allow position: static 2',
         code: `
           .parent {
             position: relative;
 
-            & > .child.relativeToParent {
+            & > .child {
               position: static;
             }
           }
@@ -152,16 +139,7 @@ test('parent-child-policy', {
         code: '.bad { & > .test { position: static; } }',
         warnings: [
           messages['missing position relative'],
-          messages['missing relativeToParent className'],
         ]
-      },
-      {
-        code: '.bad { & > .test.relativeToParent { position: static; } }',
-        warnings: [messages['missing position relative']]
-      },
-      {
-        code: '.bad { position: relative; & > .test { position: static; } }',
-        warnings: [messages['missing relativeToParent className']]
       },
       {
         title: '└─ take @media into account',
@@ -322,12 +300,11 @@ test('parent-child-policy', {
       { code: `.good { pointer-events: none; & > * { pointer-events: auto; } }` },
       { code: `.good { &::after { pointer-events: none; } }` },
       {
-        title: 'allow position: static',
         code: `
-          .test {
+          .parent {
             position: relative;
 
-            & > .relativeToParent {
+            & > .child {
               position: static;
             }
           }


### PR DESCRIPTION
New linting rules

- `.relativeToParent` requirement has been removed when setting a direct child to `position: static;`. It was added to make sure that the receiver of `position: static` is aware of a breach of containment by its child. This should be clear from the fact that you're setting `position: static` therefore we opted to remove the signalling class.
- New layout class naming rules. Layout classes must now end in the suffix `Layout`. E.g. `styles.childLayout` or `'childLayout'`. Classes ending in `Layout`, must be styled with a direct child selector. This combo allows us to enforce you're only passing layout properties to layout classes (a common feedback point in PRs).

@EECOLOR FYI, so you can have a look after your vacation 🏝️