### PR TITLE
Update index.js

### DIFF
--- a/library/stylelint-plugins/rules/layout-related-properties/index.js
+++ b/library/stylelint-plugins/rules/layout-related-properties/index.js
@@ -19,7 +19,7 @@ const layoutRelatedProps = [ // only allowed in child
   'z-index',
   'width', 'height',
   ['position', 'absolute'], ['position', 'fixed'],
-  'top', 'right', 'bottom', 'left',
+  'top', 'right', 'bottom', 'left', 'inset',
   'margin', 'margin-top', 'margin-right', 'margin-bottom', 'margin-left',
   'max-width', 'min-width', 'max-height', 'min-height',
   'justify-self', 'align-self',


### PR DESCRIPTION
## Changes
- `inset` is being rejected by `@kaliber/build`, while the `README.md` suggests the use of it (and is shorthand for other currently already allowed values).

## Example
See for an example below.

##### Pseudo-code
```postcss
.something {
  position: relative;

  & > .otherThing {
    position: absolute;
    inset: 0;
  }
}
```