### PR TITLE
Add url-loader for .wasm

### DIFF
--- a/library/lib/build.js
+++ b/library/lib/build.js
@@ -146,11 +146,6 @@ const rawLoader = {
   options: { esModule: false }
 }
 
-const wasmLoader = {
-  loader: 'wasm-loader',
-  options: { esModule: false }
-}
-
 module.exports = function build({ watch }) {
 
   const cwd = process.cwd()
@@ -372,7 +367,7 @@ module.exports = function build({ watch }) {
 
         {
           test: /\.wasm$/,
-          loaders: [wasmLoader]
+          loaders: [urlLoader]
         },
 
         {

--- a/library/lib/build.js
+++ b/library/lib/build.js
@@ -146,6 +146,11 @@ const rawLoader = {
   options: { esModule: false }
 }
 
+const wasmLoader = {
+  loader: 'wasm-loader',
+  options: { esModule: false }
+}
+
 module.exports = function build({ watch }) {
 
   const cwd = process.cwd()
@@ -363,6 +368,11 @@ module.exports = function build({ watch }) {
             isProduction && imageLoader,
             imageSizeLoader
           ].filter(Boolean)
+        },
+
+        {
+          test: /\.wasm$/,
+          loaders: [wasmLoader]
         },
 
         {


### PR DESCRIPTION
## Veranderingen

<!-- Hier kun je je nieuwe features aangeven  -->
- Om voor `Rive` zelf de `wasm` te serveren moet je de Webpack config aanpassen; standaard trekt `Rive` de `wasm` file uit `unpkg`.
 
## Waarom?
- In een van de projecten waar we actief aan werken start er een Rive animatie in de home hero; dit component trekt de performance toch wel een flinke tik omlaag, en dat zou ik graag tegen gaan.

## Bron
- https://help.rive.app/runtimes/overview/web-js/preloading-wasm
- https://help.rive.app/runtimes/overview/web-js/low-level-api-usage#loading-in-wasm
- https://pixelpoint.io/blog/rive-react-optimizations/