### PR TITLE
CSP header support

### DIFF
--- a/library/lib/SafeScript.js
+++ b/library/lib/SafeScript.js
@@ -6,7 +6,7 @@ let scriptHashes = null
 module.exports = { SafeScript, recordScriptHashes }
 
 function SafeScript({ dangerouslySetInnerHTML }) {
-  if (!scriptHashes) throw new Error('No script hashes present')
+  if (!scriptHashes) throw new Error('No script hashes present, can not use SafeScript in a static environment, check if your *.html.js file returns a function')
   scriptHashes.add(crypto.createHash('sha256').update(dangerouslySetInnerHTML.__html).digest('base64'))
   return React.createElement('script', { dangerouslySetInnerHTML })
 }

--- a/library/lib/SafeScript.js
+++ b/library/lib/SafeScript.js
@@ -1,19 +1,17 @@
 const crypto = require('crypto')
 const React = require('react')
 
-let scriptHashes = null
-
 module.exports = { SafeScript, recordScriptHashes }
 
 function SafeScript({ dangerouslySetInnerHTML }) {
-  if (!scriptHashes) throw new Error('No script hashes present, can not use SafeScript in a static environment, check if your *.html.js file returns a function')
-  scriptHashes.add(crypto.createHash('sha256').update(dangerouslySetInnerHTML.__html).digest('base64'))
+  if (!global.scriptHashes) throw new Error('No script hashes present')
+  global.scriptHashes.add(crypto.createHash('sha256').update(dangerouslySetInnerHTML.__html).digest('base64'))
   return React.createElement('script', { dangerouslySetInnerHTML })
 }
 
 function recordScriptHashes(newScriptHashses, callback) {
-  scriptHashes = newScriptHashses
+  global.scriptHashes = newScriptHashses
   const result = callback()
-  scriptHashes = null
+  global.scriptHashes = null
   return result
 }

--- a/library/lib/SafeScript.js
+++ b/library/lib/SafeScript.js
@@ -1,0 +1,19 @@
+const crypto = require('crypto')
+const React = require('react')
+
+let scriptHashes = null
+
+module.exports = { SafeScript, recordScriptHashes }
+
+function SafeScript({ dangerouslySetInnerHTML }) {
+  if (!scriptHashes) throw new Error('No script hashes present')
+  scriptHashes.add(crypto.createHash('sha256').update(dangerouslySetInnerHTML.__html).digest('base64'))
+  return React.createElement('script', { dangerouslySetInnerHTML })
+}
+
+function recordScriptHashes(newScriptHashses, callback) {
+  scriptHashes = newScriptHashses
+  const result = callback()
+  scriptHashes = null
+  return result
+}

--- a/library/lib/eval-in-fork.js
+++ b/library/lib/eval-in-fork.js
@@ -8,8 +8,14 @@ attempt(() => {
   function handleMessage(source) {
     attempt(() => {
       process.off('message', handleMessage)
-      const { template, renderer } = evalSource(source)
-      const result = renderer(template)
+
+      const { template, renderer, recordScriptHashes } = evalSource(source)
+      const scriptHashes = new Set()
+      const result = recordScriptHashes(scriptHashes, () =>
+        renderer(template)
+      )
+      if (scriptHashes.size)
+        console.log('[Warning]: generating a static template with inline scripts, if you want to use a CSP header, make it a dynamic template by exporting a function')
 
       process.send(result, e =>
         attempt(() => {

--- a/library/lib/rollbar.js
+++ b/library/lib/rollbar.js
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import merge from 'rollbar/src/merge'
+import { SafeScript } from './SafeScript'
 
 const snippet = fs.readFileSync(__non_webpack_require__.resolve('rollbar/dist/rollbar.snippet.js'), 'utf8')
 
@@ -15,5 +16,5 @@ const defaultOptions = {
 export default function rollbar(options, nonSerializableRollbarConfig = '/* no non-serializable config */') {
   const config = JSON.stringify(merge(defaultOptions, options))
   const __html = `var _rollbarConfig = ${config};${nonSerializableRollbarConfig};${snippet}`
-  return <script dangerouslySetInnerHTML={{ __html }} />
+  return <SafeScript dangerouslySetInnerHTML={{ __html }} />
 }

--- a/library/lib/stylesheet.js
+++ b/library/lib/stylesheet.js
@@ -5,6 +5,7 @@
 */
 
 import hotCssReplacementClient from './hot-css-replacement-client?transpiled-javascript-string'
+import { SafeScript } from './SafeScript'
 
 const isWatch = process.env.WATCH
 
@@ -18,10 +19,10 @@ export default __webpack_css_chunk_hashes__
 function createHotReloadClient() {
   const [ port, cssHashes, chunkName, publicPath ] = [ __webpack_websocket_port__, __webpack_css_chunk_hashes__, __webpack_chunkname__, __webpack_public_path__ ]
   return (
-    <script
+    <SafeScript
       key='stylesheet_hotCssReplacementClient'
       dangerouslySetInnerHTML={{
-      __html: `(${hotCssReplacementClient})(${port}, ${JSON.stringify(cssHashes)}, '${chunkName}', '${publicPath}')`
+        __html: `(${hotCssReplacementClient})(${port}, ${JSON.stringify(cssHashes)}, '${chunkName}', '${publicPath}')`
       }}
     />
   )

--- a/library/lib/universalComponents.js
+++ b/library/lib/universalComponents.js
@@ -1,5 +1,6 @@
 import { hydrateRoot, createRoot } from 'react-dom/client'
 import { safeJsonStringify } from '@kaliber/safe-json-stringify'
+import { SafeScript } from './SafeScript'
 
 const containerMarker = 'data-kaliber-component-container'
 const E = /** @type {any} */ ('kaliber-component-container')
@@ -19,7 +20,7 @@ export function ComponentServerWrapper({ componentName, props, renderedComponent
 
       {/* Use render blocking script to set a container marker and remove the custom components.
           This ensures the page is never rendered with the intermediate structure */}
-      <script dangerouslySetInnerHTML={{ __html: scriptContent }} />
+      <SafeScript dangerouslySetInnerHTML={{ __html: scriptContent }} />
     </>
   )
 }

--- a/library/webpack-loaders/template-loader.js
+++ b/library/webpack-loaders/template-loader.js
@@ -15,5 +15,6 @@ TemplateLoader.pitch = function TemplateLoaderPitch(remainingRequest, precedingR
   // This should tell us what we need to use: https://webpack.js.org/configuration/module/#rule-enforce
   return `|export { default as template } from '-!${precedingRequest}!${remainingRequest}?template-source'
           |export { default as renderer } from '${rendererPath}'
+          |export { recordScriptHashes } from '@kaliber/build/lib/SafeScript'
           |`.split(/^[ \t]*\|/m).join('')
 }

--- a/library/webpack-plugins/template-plugin.js
+++ b/library/webpack-plugins/template-plugin.js
@@ -177,14 +177,16 @@ async function createStaticTemplate(name, source, map) {
 function createDynamicTemplate(name, ext) {
   return new RawSource(
     `|const envRequire = process.env.NODE_ENV === 'production' ? require : require('import-fresh')
-     |const { template, renderer } = envRequire('./${name}${ext}')
+     |const { template, renderer, recordScriptHashes } = envRequire('./${name}${ext}')
      |
      |Object.assign(render, template)
      |
      |module.exports = render
      |
-     |function render(props) {
-     |  return renderer(template(props))
+     |function render(props, scriptHashes) {
+     |  return recordScriptHashes(scriptHashes, () =>
+     |    renderer(template(props))
+     |  )
      |}
      |`.replace(/^[ \t]*\|/gm, '')
   )


### PR DESCRIPTION
This pull request adds Content Security Policy header support.

Blocking `unsafe-inline` is one of the most important directives to avoid. But this will make all inline script tags unusable. Two approaches to solve 'trusted' inline scripts:

1. Provide a hash in the CSP header of the code in the script
2. Use a `nonce`, a value that is unique for each request and is both present in the header and in the script tag

Option 2. is the easiest to implement. The problem with this approach is that each request will get a unique header, making caching layers outside of the application unusable.

So we are stuck with option 1. For script tags created with this library a hash could be determined without using code. In real applications we however also use the script tags to provide information the `dataLayer`. While not the only use case, it's one of the more well known ones.

What we do in this pull request:

- Switch all `<script>` tags to our `<SafeScript>` tag
- When rendering set a global variable to collect hashes
- When the `SafeScript` tag renders, it creates a hash of the content and adds it to the collection
- The collected hashes are stored in the response
- The helmet CSP middleware uses the hashes in the creation of the CSP header

----

Note: the code should still be tested in a real environment