### PR TITLE
Use more generic handlerequest instead of match

### DIFF
--- a/library/lib/serve.js
+++ b/library/lib/serve.js
@@ -140,7 +140,7 @@ function serveIndexWithRouting(file, req, res, next) {
   const location = parsePath(req.url)
 
   if (routeTemplate.handleRequest)
-    return routeTemplate.handleRequest(req, res, location).catch(error => {
+    return routeTemplate.handleRequest(location, req, res).catch(error => {
       reportServerError(error, req)
       serveInternalServerError(error, req, res, next)
     })

--- a/library/lib/serve.js
+++ b/library/lib/serve.js
@@ -69,7 +69,7 @@ app.use((err, req, res, next) => {
     return res.status(err.status).send()
 
   reportServerError(err, req)
-  serveInternalServerError(err, { req, res, next })
+  serveInternalServerError(err, req, res, next)
 })
 
 app.listen(port, () => console.log(`Server listening at port ${port}`))
@@ -88,7 +88,9 @@ async function resolveFile(req, res, next) {
     for (const dir of dirs) {
       for (const [file, handler] of combinations) {
         const filePath = resolve(dir, file)
-        if (await fileExists(filePath)) return handler(filePath)
+        if (await fileExists(filePath)) {
+          return handler(filePath)
+        }
       }
     }
 
@@ -135,8 +137,13 @@ function possibleDirectories(path) {
 
 function serveIndexWithRouting(file, req, res, next) {
   const routeTemplate = envRequire(file)
-
   const location = parsePath(req.url)
+
+  if (routeTemplate.handleRequest)
+    return routeTemplate.handleRequest(req, res, location).catch(error => {
+      reportServerError(error, req)
+      serveInternalServerError(error, req, res, next)
+    })
 
   const [dataOrPromise, template] = getDataAndRouteTemplate(routeTemplate, location, req)
 


### PR DESCRIPTION
Previously it was not possible to stream a response without jumping through hoops.
With this change, we can add a generic `handleRequest(req, res, location)` function, instead of the `Index.routes.match(location, req)` function. In this way we expose the express response object, and have full control of the way we handle the request/response.

In index.html.js we would add the following code snippet to use this functionality.
```js
Index.handleRequest = async function handleRequest(req, res, location) {
  if (location.pathname === routeMap.api.v1.stream())
    return handleStreamingRequest(req, res)

  const { status, headers, data } = await match(location, req)

  if (data.noBody) return res.status(status).set(headers).send(null)
  if (data.body) return res.status(status).set(headers).send(data.body)

  const html = htmlReactRenderer(Index({ location, data }))
  return res.status(status).set(headers).send(html)
}
```